### PR TITLE
Switching cloning method from SSH to HTTPS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This theme is meant to be updated as Ghost develops. Feel free to [request featu
 
 1. Navigate to your Ghost theme directory ghost/content/themes
 
-2. [Download](https://github.com/cvandonderen/photoghost/archive/master.zip) the theme zipfile from GitHub OR clone the theme repo using the ```git clone git@github.com:cvandonderen/photoghost.git "photoghost"``` command
+2. [Download](https://github.com/cvandonderen/photoghost/archive/master.zip) the theme zipfile from GitHub OR clone the theme repo using the ```git clone https://github.com/cvandonderen/photoghost "photoghost"``` command
 
 3. Restart ghost and log into your dashboard
 


### PR DESCRIPTION
HTTPS method doesn't need that you uploaded your ssh key pair on github before cloning contrary to ssh.
So it's easier to use, you can just clone the repository staying anonymous and have a read only access while keeping an up to date installation (contrary to git).

I'm totally conscious that my small pull request could be rejected, because github seems to have change his politic about cloning and now highlighting SSH.
